### PR TITLE
Add skip timer button

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlypausinghealthily/activities/TimerActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypausinghealthily/activities/TimerActivity.java
@@ -65,6 +65,7 @@ public class TimerActivity extends BaseActivity implements LoaderManager.LoaderC
     private TextView timerText;
     private ImageButton playButton;
     private ImageButton resetButton;
+    private ImageButton skipButton;
     private NumberPicker secondsPicker;
     private NumberPicker minutesPicker;
     private NumberPicker hoursPicker;
@@ -142,10 +143,11 @@ public class TimerActivity extends BaseActivity implements LoaderManager.LoaderC
 
         constraintSetRunning = new ConstraintSet();
         constraintSetRunning.clone(mainContent);
-        int[] chainViews = {R.id.button_reset, R.id.button_playPause};
-        float[] chainWeights = {0.5f, 0.5f};
+        int[] chainViews = {R.id.button_reset, R.id.button_playPause, R.id.button_skip};
+        float[] chainWeights = {0.5f, 0.5f, 0.5f};
         constraintSetRunning.createHorizontalChain(0, ConstraintSet.LEFT, 0, ConstraintSet.RIGHT, chainViews, chainWeights, ConstraintSet.CHAIN_PACKED);
         constraintSetRunning.setVisibility(R.id.button_reset, View.VISIBLE);
+        constraintSetRunning.setVisibility(R.id.button_skip, View.VISIBLE);
         constraintSetRunning.setVisibility(R.id.picker_layout, View.INVISIBLE);
         constraintSetRunning.setVisibility(R.id.progressBar, View.VISIBLE);
         constraintSetRunning.setVisibility(R.id.timerText, View.VISIBLE);
@@ -217,6 +219,7 @@ public class TimerActivity extends BaseActivity implements LoaderManager.LoaderC
         timerText = (TextView) findViewById(R.id.timerText);
         playButton = (ImageButton) findViewById(R.id.button_playPause);
         resetButton = (ImageButton) findViewById(R.id.button_reset);
+        skipButton = (ImageButton) findViewById(R.id.button_skip);
         exerciseSetSpinner = (Spinner) findViewById(R.id.spinner_choose_exercise_set);
         exerciseSetSpinner.setAdapter(exerciseSetAdapter);
         exerciseSetSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -291,6 +294,10 @@ public class TimerActivity extends BaseActivity implements LoaderManager.LoaderC
             case R.id.button_reset:
                 if(mTimerService != null)
                     mTimerService.stopAndResetTimer();
+                break;
+            case R.id.button_skip:
+                if(mTimerService != null)
+                    mTimerService.skipTimer();
                 break;
             //case R.id.button_chooseExercise:
             //    startActivity(new Intent(this, ManageExerciseSetsActivity.class));

--- a/app/src/main/java/org/secuso/privacyfriendlypausinghealthily/service/TimerService.java
+++ b/app/src/main/java/org/secuso/privacyfriendlypausinghealthily/service/TimerService.java
@@ -221,6 +221,12 @@ public class TimerService extends Service {
         sendBroadcast(buildBroadcast());
     }
 
+    public synchronized void skipTimer () {
+        Intent exerciseIntent = new Intent(this, ExerciseActivity.class);
+        exerciseIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(exerciseIntent);
+    }
+
     public synchronized boolean isPaused() { return !isRunning && initialDuration != 0 && remainingDuration > 0 && remainingDuration != initialDuration; }
 
     public synchronized boolean isRunning() {

--- a/app/src/main/res/layout/activity_timer.xml
+++ b/app/src/main/res/layout/activity_timer.xml
@@ -312,6 +312,22 @@
                 app:srcCompat="@drawable/ic_play_arrow_black"
                 app:tint="@color/darkblue" />
 
+            <ImageButton
+                android:id="@+id/button_skip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:hapticFeedbackEnabled="true"
+                android:onClick="onClick"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:srcCompat="@drawable/ic_skip_next_black_48dp"
+                app:tint="@color/darkblue" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Current "Start break" notification button is not very reliable when not pressed right after the timer ends and sometimes leads to the timer being reset instead.
This PR adds a skip (Start break) button right to timer screen for faster starts of exercises when the timer gets reset.